### PR TITLE
fix: propagate compiler diagnostics to playground

### DIFF
--- a/crates/backend/src/services/compile.rs
+++ b/crates/backend/src/services/compile.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use actix_web::{rt::task::spawn_blocking, web::Json, HttpResponse, Responder};
+use actix_web::{HttpResponse, Responder, rt::task::spawn_blocking, web::Json};
 use typescript_type_def::TypeDef;
 
 use crate::services::sandbox::Sandbox;
@@ -73,7 +73,7 @@ pub async fn route_compile(req: Json<CompilationRequest>) -> impl Responder {
         },
         Err(err) => {
             eprintln!("{:?}", err);
-            HttpResponse::InternalServerError().finish()
+            HttpResponse::InternalServerError().body("Backend failed to run the compiler")
         },
     }
 }

--- a/crates/backend/src/services/sandbox.rs
+++ b/crates/backend/src/services/sandbox.rs
@@ -1,18 +1,18 @@
 use std::{
     ffi::OsStr,
     fs::{self, File},
-    io::{prelude::*, BufReader, ErrorKind},
+    io::{BufReader, ErrorKind, prelude::*},
     os::unix::prelude::PermissionsExt,
     path::{Path, PathBuf},
     time::Duration,
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use tempfile::TempDir;
 use tokio::process::Command;
 
-use crate::services::{CompilationRequest, CompilationResult};
 use crate::services::solang_image::solang_docker_image;
+use crate::services::{CompilationRequest, CompilationResult};
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 const DOCKER_WORKDIR: &str = "/builds/contract/";
@@ -57,10 +57,10 @@ fn sanitize_compiler_flags(flags: &[String]) -> Result<Vec<String>> {
             let valid = match expected {
                 ExpectedValue::Emit => {
                     matches!(trimmed, "ast-dot" | "cfg" | "llvm-ir" | "llvm-bc" | "object" | "asm")
-                }
+                },
                 ExpectedValue::OptimizeLevel => {
                     matches!(trimmed, "none" | "less" | "default" | "aggressive")
-                }
+                },
             };
 
             if !valid {
@@ -106,7 +106,10 @@ pub fn build_compile_command(
     compiler_flags: &[String],
     output_dir: &Path,
 ) -> Command {
-    println!("Input dir: {:?}\nMain file: {}\nOutput dir: {:?}", input_dir, main_file, output_dir);
+    println!(
+        "Input dir: {:?}\nMain file: {}\nOutput dir: {:?}",
+        input_dir, main_file, output_dir
+    );
     // Base docker command
     let mut cmd = docker_command!(
         "run",
@@ -182,15 +185,14 @@ impl Sandbox {
         let scratch = TempDir::with_prefix("solang_playground").context("failed to create scratch directory")?;
         let input_dir = scratch.path().join("input");
         let output_dir = scratch.path().join("output");
-        
+
         fs::create_dir(&input_dir).context("failed to create input directory")?;
         fs::create_dir(&output_dir).context("failed to create output directory")?;
 
-        fs::set_permissions(&input_dir, PermissionsExt::from_mode(0o777))
-            .context("failed to set input permissions")?;
+        fs::set_permissions(&input_dir, PermissionsExt::from_mode(0o777)).context("failed to set input permissions")?;
         fs::set_permissions(&output_dir, PermissionsExt::from_mode(0o777))
             .context("failed to set output permissions")?;
-        
+
         Ok(Sandbox {
             scratch,
             input_dir,
@@ -203,10 +205,10 @@ impl Sandbox {
         // Determine main file name
         let main_file_name = req.main_file.as_deref().unwrap_or("input.sol");
         let compiler_flags = sanitize_compiler_flags(req.compiler_flags.as_deref().unwrap_or(&[]))?;
-        
+
         // Write the main source file
         self.write_source_file(main_file_name, &req.source)?;
-        
+
         // Write additional files if provided
         if let Some(files) = &req.files {
             for (filename, content) in files {
@@ -254,9 +256,9 @@ impl Sandbox {
 
         let compile_stderr = match compile_log_stderr_file_path {
             Some(path) => fs::read_to_string(&path).context("failed to read compile stderr")?,
-            None => "No stderr.log file found".to_string(),
+            None => String::new(),
         };
-        let compile_stderr = extract_error_message(&compile_stderr);
+        let compile_stderr = sanitize_compiler_stderr(&compile_stderr);
 
         let stdout = String::from_utf8(output.stdout).context("failed to convert vec to string")?;
         let stderr = String::from_utf8(output.stderr).context("failed to convert vec to string")?;
@@ -336,7 +338,7 @@ async fn run_command(mut command: Command) -> Result<std::process::Output> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let id = stdout.lines().next().context("missing compiler ID")?.trim();
     let stderr = &output.stderr;
-    
+
     let mut command = docker_command!("wait", id);
     println!("ID: {:?}\nwait: {:?}", id, command);
 
@@ -370,17 +372,13 @@ async fn run_command(mut command: Command) -> Result<std::process::Output> {
     Ok(output)
 }
 
-pub fn extract_error_message(log: &str) -> String {
-    // Remove ANSI escape codes (used for terminal colors)
+pub fn sanitize_compiler_stderr(log: &str) -> String {
     let cleaned_log = remove_ansi_escape_codes(log);
-    let cleaned_log = cleaned_log.trim();
 
-    // Find the start of the actual error message by looking for the keyword "error:"
-    if let Some(start) = cleaned_log.find("error:") {
-        // Extract the error message starting from the keyword "error:" but ignore the keyword itself
-        cleaned_log[start + "error:".len()..].trim().to_string()
+    if cleaned_log.trim().is_empty() {
+        String::new()
     } else {
-        cleaned_log.to_string()
+        cleaned_log
     }
 }
 
@@ -389,4 +387,43 @@ fn remove_ansi_escape_codes(log: &str) -> String {
     // Use a regex pattern to remove ANSI escape codes
     let re = regex::Regex::new(r"\x1B\[[0-9;]*[a-zA-Z]").unwrap();
     re.replace_all(log, "").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_compiler_stderr;
+
+    #[test]
+    fn strips_ansi_escape_codes() {
+        let stderr = "\u{1b}[0merror: invalid token\u{1b}[0m\n";
+
+        assert_eq!(sanitize_compiler_stderr(stderr), "error: invalid token\n");
+    }
+
+    #[test]
+    fn preserves_warnings_and_context_before_error() {
+        let stderr = "warning: unused variable\nnote: while compiling input.sol\nerror: expected expression\n";
+
+        assert_eq!(sanitize_compiler_stderr(stderr), stderr);
+    }
+
+    #[test]
+    fn preserves_multiline_source_spans() {
+        let stderr =
+            "error: expected expression\n  input.sol:3:20\n   |\n 3 |         uint64 x =\n   |                    ^\n";
+
+        assert_eq!(sanitize_compiler_stderr(stderr), stderr);
+    }
+
+    #[test]
+    fn preserves_output_without_lowercase_error_marker() {
+        let stderr = "LLVM ERROR: unsupported operation\nfatal: backend aborted\n";
+
+        assert_eq!(sanitize_compiler_stderr(stderr), stderr);
+    }
+
+    #[test]
+    fn returns_empty_string_for_empty_or_whitespace_output() {
+        assert_eq!(sanitize_compiler_stderr("  \n\t"), "");
+    }
 }

--- a/packages/frontend/src/hooks/useCompile.tsx
+++ b/packages/frontend/src/hooks/useCompile.tsx
@@ -34,6 +34,16 @@ interface ICompilationErrorResponse {
 
 type CompilationApiResponse = ICompilationSuccessResponse | ICompilationErrorResponse;
 
+interface CompilationErrorPayload {
+    compile_stderr?: unknown;
+    compile_stdout?: unknown;
+    stderr?: unknown;
+    stdout?: unknown;
+}
+
+const GENERIC_COMPILER_ERROR = "Compiler failed without diagnostic output";
+const GENERIC_BACKEND_ERROR = "Compiler service is unavailable. Please try again.";
+
 /**
  * Extract just the filename from a state path like "explorer.items.src.items['main.sol']"
  */
@@ -75,6 +85,46 @@ function logCompilerOutput(result: CompilationApiResponse) {
             logger.error(compileStderr);
         }
     }
+}
+
+function nonEmptyString(value: unknown): string | null {
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export function selectCompilerDiagnostic(payload: CompilationErrorPayload | null | undefined): string {
+    return nonEmptyString(payload?.compile_stderr)
+        ?? nonEmptyString(payload?.compile_stdout)
+        ?? nonEmptyString(payload?.stderr)
+        ?? nonEmptyString(payload?.stdout)
+        ?? GENERIC_COMPILER_ERROR;
+}
+
+async function parseCompileResponse(res: Response) {
+    const bodyText = await res.text().catch(() => "");
+    const fallbackMessage = bodyText.trim() || res.statusText || `HTTP ${res.status}`;
+    let result = null;
+
+    if (bodyText.trim().length > 0) {
+        try {
+            result = JSON.parse(bodyText);
+        } catch {
+            result = null;
+        }
+    }
+
+    if (!result) {
+        return {
+            success: false,
+            message: fallbackMessage,
+            result: null,
+        };
+    }
+
+    return {
+        success: res.ok,
+        message: res.ok ? res.statusText : fallbackMessage,
+        result,
+    };
 }
 
 function useCompile() {
@@ -120,23 +170,12 @@ function useCompile() {
                 }),
             };
 
-            const { result, success, message } = await fetchWithTimeout(`/compile`, opts, async (res) => {
-                const result = await res.json().catch(() => null);
-                console.log('compilation result', result);
-                if (!result) {
-                    return {
-                        success: false,
-                        message: res.statusText,
-                        result: null,
-                    };
-                }
-
-                return {
-                    success: res.ok,
-                    message: res.statusText,
-                    result: result,
-                };
-            });
+            const { result, success, message } = await fetchWithTimeout(
+                `/compile`,
+                opts,
+                parseCompileResponse,
+            );
+            console.log('compilation result', result);
 
             let err = "";
 
@@ -161,13 +200,14 @@ function useCompile() {
                         err: null
                     };
                 } else {
-                    logCompilerOutput(result);
-                    const message = normalizeOutput(result.payload.compile_stderr) || normalizeOutput(result.payload.stderr) || "Compilation failed";
+                    const message = selectCompilerDiagnostic(result.payload);
+                    logger.error(message);
                     err = message
                 }
             } else {
-                logger.error(message);
-                err = message
+                const backendMessage = message || GENERIC_BACKEND_ERROR;
+                logger.error(backendMessage);
+                err = backendMessage
             }
             console.log('[tur] compilation error:', err)
             return {
@@ -175,14 +215,14 @@ function useCompile() {
                 err
             }
         } catch {
-            logger.error("Contract compilation failed!");
+            logger.error(GENERIC_BACKEND_ERROR);
         }
         finally {
             store.send({ type: "setDialogSpinner", show: false });
         }
         return {
             data: null,
-            err: 'Error compiling contract'
+            err: GENERIC_BACKEND_ERROR
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1898 by preserving Solang compiler diagnostics through the playground compile flow.

Compiler diagnostics were being reduced before reaching the UI: the backend kept only the substring after the first lowercase `error:` in compiler stderr, and the frontend displayed only one diagnostic field. This could hide warnings/context, multiline source spans, diagnostics without that exact marker, and useful fallback output.

## What changed

- Preserve the full ANSI-stripped compiler stderr in the backend.
- Avoid replacing empty compiler stderr with a placeholder that would shadow useful fallback output.
- Return a small non-secret body for backend failures instead of an empty HTTP 500 response.
- Display compiler diagnostics in the frontend using this fallback order:
  `compile_stderr > compile_stdout > stderr > stdout > generic fallback`.
- Read non-200 response body text before falling back to `statusText`.
- Keep the API shape, compiler dependency, Docker image, and generated bindings unchanged.

## Verification

Ran locally:

- `git diff --check`
- `rustfmt --check crates/backend/src/services/compile.rs crates/backend/src/services/sandbox.rs`
- `cargo test -p backend`
- `cargo test`
- `npm run build --workspace=packages/frontend`

Manual Docker-backed check:

- Posted an invalid contract to `/compile` and verified that the response preserves the compiler diagnostic text.
- Verified multiline/source-span formatting is preserved.
- Verified a valid compile control still succeeds.

`npm run test --workspace=packages/app` requires a running server at `localhost:9000`; without that server it fails with connection errors.
